### PR TITLE
Updates for affjax and misc build config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-dist: trusty
+dist: bionic
 sudo: required
 node_js: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,15 @@ env:
   - PATH=$HOME:$HOME/purescript:$PATH
 
 install:
-- PURS_VER=v0.13.2
-- SPAGO_VER=0.8.5.0
+- PURS_VER=v0.13.5
+- SPAGO_VER=0.10.0.0
 - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$PURS_VER/linux64.tar.gz
-- wget -O $HOME/spago.tar.gz https://github.com/spacchetti/spago/releases/download/0.8.5.0/linux.tar.gz
+- wget -O $HOME/spago.tar.gz https://github.com/spacchetti/spago/releases/download/$SPAGO_VER/linux.tar.gz
 - tar -xvf $HOME/purescript.tar.gz -C $HOME/
 - tar -xvf $HOME/spago.tar.gz -C $HOME/
 - chmod a+x $HOME/purescript/purs
 - chmod a+x $HOME/spago
-- npm install -g bower@^1.8.8 pulp@^13.0.0
 - spago install
-- bower install
 
 script:
 - export VERSION=branch-job-$TRAVIS_JOB_NUMBER
@@ -27,5 +25,3 @@ script:
 - if [[ "$TRAVIS_TAG" != "" ]]; then export VERSION=$TRAVIS_TAG; fi
 - spago build
 - spago test
-- rm -rf .spago output
-- pulp build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: example/public/bundle.js
 example/public/bundle.js:
-	spago bundle-app -p example/src/**/*.purs --main Client
+	spago bundle-app --main Client --path=example/src/*.purs --to=example/public/bundle.js
 
 run-example: example/public/bundle.js
-	spago run -w --main Server -p example/src/**/*.purs
+	spago run --main Server --path=example/src/*.purs

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,17 +1,11 @@
 let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.5-20191125/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
 
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.2-20190725/src/packages.dhall sha256:60cc03d2c3a99a0e5eeebb16a22aac219fa76fe6a1686e8c2bd7a11872527ea3
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.5-20191125/src/packages.dhall sha256:650bf74df7b44b0f55a9cbd7cf35d95fb63f4110faa922567c61c7acb9581457
 
 let overrides = {=}
 
-let additions =
-      { jquery =
-          mkPackage
-          [ "web-dom", "effect", "foreign" ]
-          "https://github.com/purescript-contrib/purescript-jquery.git"
-          "v5.0.0"
-      }
+let additions = {=}
 
 in  upstream // overrides // additions

--- a/src/Type/Trout/Client.purs
+++ b/src/Type/Trout/Client.purs
@@ -8,12 +8,12 @@ module Type.Trout.Client
 
 import Prelude
 
-import Affjax (Request, defaultRequest, request)
+import Affjax (Request, defaultRequest, printError, request)
 import Affjax.ResponseFormat (json, string) as AXResponseFormat
-import Affjax.ResponseFormat (printResponseFormatError)
 import Control.Monad.Except.Trans (throwError)
 import Data.Argonaut (class DecodeJson, decodeJson)
 import Data.Array (singleton)
+import Data.Bifunctor (rmap)
 import Data.Either (Either(..))
 import Data.Foldable (foldl)
 import Data.HTTP.Method as Method
@@ -157,9 +157,9 @@ instance hasMethodClientMethodJson
     r <- toAffjaxRequest req
            # _ { method = toMethod method, responseFormat = AXResponseFormat.json }
            # request
-           # map _.body
+           # map (rmap _.body)
     case r of
-      Left err -> throwError (error $ printResponseFormatError err)
+      Left err -> throwError (error $ printError err)
       Right json ->
         case decodeJson json of
           Left err -> throwError (error err)
@@ -172,9 +172,9 @@ instance hasMethodClientsHTMLString
     r <- toAffjaxRequest req
            # _ { method = toMethod method, responseFormat = AXResponseFormat.string }
            # request
-           # map _.body
+           # map (rmap _.body)
     case r of
-      Left err -> throwError (error $ printResponseFormatError err)
+      Left err -> throwError (error $ printError err)
       Right x -> pure x
 
 asClients :: forall r mk. HasClients r mk => Proxy r -> mk


### PR DESCRIPTION
The main issue here is that [`trout-client` was removed from `package-sets`](https://github.com/purescript/package-sets/commit/7a47891dc951a7efcd7b69c7127fb715e448c492#diff-b3410802f18bddc7fc759d57c5903af4) due to its Affjax dependency. Affjax has since been updated and is included in `package-sets` once again. I have made the updates necessary to use the latest version of Affjax; so, after merging this, we should be able to get `trout-client` reinstated as well.

The other changes are build-related (updating to latest package set and Spago, etc.) and generally not interesting. If you have any particular questions, then please let me know!