### PR TITLE
Update for argonaut-codecs v7.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,20 +14,23 @@
     "output"
   ],
   "dependencies": {
-    "purescript-affjax": "^v10.0.0",
-    "purescript-argonaut-generic": "^v5.0.0",
-    "purescript-hyper": "^v0.11.0",
+    "purescript-affjax": "^v10.1.0",
+    "purescript-argonaut-generic": "^v6.0.0",
+    "purescript-hyper": "^v0.11.1",
     "purescript-hypertrout": "^v0.11.0",
     "purescript-jquery": "^v5.0.0",
     "purescript-node-http": "^v5.0.2",
     "purescript-prelude": "^v4.1.1",
     "purescript-psci-support": "^v4.0.0",
-    "purescript-trout": "^v0.12.2"
+    "purescript-trout": "^v0.12.3"
   },
   "resolutions": {
-    "purescript-hyper": "^v0.11.0",
+    "purescript-hyper": "^v0.11.1",
     "purescript-node-buffer": "^6.0.0",
     "purescript-web-dom": "2 - 4",
-    "purescript-web-events": "^2.0.0"
+    "purescript-web-events": "^2.0.0",
+    "purescript-argonaut-codecs": "^7.0.0",
+    "purescript-argonaut": "^7.0.0",
+    "purescript-argonaut-traversals": "^8.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,10 +1,14 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.5-20191125/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.5-20191125/src/packages.dhall sha256:650bf74df7b44b0f55a9cbd7cf35d95fb63f4110faa922567c61c7acb9581457
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8/packages.dhall sha256:0e95ec11604dc8afc1b129c4d405dcc17290ce56d7d0665a0ff15617e32bbf03
 
-let overrides = {=}
+-- These overrides can be removed when the package set is next updated.
+let overrides = 
+  { argonaut = upstream.argonaut // { version = "v7.0.0" } 
+  , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
+  , argonaut-generic = upstream.argonaut-generic // { version = "v6.0.0" }
+  , argonaut-traversals = upstream.argonaut-traversals // { version = "v8.0.0" }
+  , trout = upstream.trout // { version = "v0.12.3" }
+  }
 
 let additions = {=}
 

--- a/src/Type/Trout/Client.purs
+++ b/src/Type/Trout/Client.purs
@@ -14,7 +14,7 @@ import Affjax.RequestBody (json) as AXRequestBody
 import Affjax.RequestHeader (RequestHeader(..))
 import Affjax.ResponseFormat (json, string) as AXResponseFormat
 import Control.Monad.Except.Trans (throwError)
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson)
+import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, printJsonDecodeError)
 import Data.Array ((:), singleton)
 import Data.Bifunctor (rmap)
 import Data.Either (Either(..))
@@ -28,20 +28,7 @@ import Effect.Aff (Aff)
 import Effect.Exception (error)
 import Prim.Row (class Cons)
 import Type.Proxy (Proxy(..))
-import Type.Trout
-  ( type (:<|>)
-  , type (:=)
-  ,type (:>)
-  , Capture
-  , CaptureAll
-  , Header
-  , Lit
-  , Method
-  , QueryParam
-  , QueryParams
-  , ReqBody
-  , Resource
-  )
+import Type.Trout (type (:<|>), type (:=), type (:>), Capture, CaptureAll, Header, Lit, Method, QueryParam, QueryParams, ReqBody, Resource)
 import Type.Trout.ContentType.HTML (HTML)
 import Type.Trout.ContentType.JSON (JSON)
 import Type.Trout.Header (class ToHeader, toHeader)
@@ -212,7 +199,7 @@ instance hasMethodClientMethodJson
       Left err -> throwError (error $ printError err)
       Right json ->
         case decodeJson json of
-          Left err -> throwError (error err)
+          Left err -> throwError (error (printJsonDecodeError err))
           Right x -> pure x
 
 instance hasMethodClientsHTMLString


### PR DESCRIPTION
This is the final PR to the purescript-hyper organization for updating to the new argonaut-codecs! Whew!

The overrides in the spago.dhall file can be removed when this library next updates its package set, but the code change will need a new release so that it can be pointed to in the next package set.

Thanks for all your work to help get these in!