### PR TITLE
Process the response outside the library except json decoding

### DIFF
--- a/example/src/Client.purs
+++ b/example/src/Client.purs
@@ -1,10 +1,14 @@
 module Client where
 
 import Prelude hiding (div)
+import Affjax (printError)
+import Control.Monad.Except.Trans (throwError)
+import Data.Either (Either(..))
 import Data.Foldable (foldMap)
 import Effect (Effect)
 import Effect.Aff (launchAff)
 import Effect.Class (liftEffect)
+import Effect.Exception (error)
 import JQuery (body, setHtml)
 import Site (site)
 import Text.Smolder.Renderer.String (render)
@@ -16,5 +20,7 @@ main = do
   b <- body
   void $ launchAff do
     let {tasks} = asClients site
-    ts <- tasks."GET"
-    liftEffect (setHtml (foldMap (render <<< encodeHTML) ts) b)
+    r <- tasks."GET"
+    case r of
+      Left err -> throwError (error (printError err))
+      Right ts -> liftEffect (setHtml (foldMap (render <<< encodeHTML) ts) b)

--- a/example/src/Client.purs
+++ b/example/src/Client.purs
@@ -1,7 +1,6 @@
 module Client where
 
 import Prelude hiding (div)
-import Affjax (printError)
 import Control.Monad.Except.Trans (throwError)
 import Data.Either (Either(..))
 import Data.Foldable (foldMap)
@@ -12,7 +11,7 @@ import Effect.Exception (error)
 import JQuery (body, setHtml)
 import Site (site)
 import Text.Smolder.Renderer.String (render)
-import Type.Trout.Client (asClients)
+import Type.Trout.Client (asClients, printError)
 import Type.Trout.ContentType.HTML (encodeHTML)
 
 main :: Effect Unit


### PR DESCRIPTION
First of all thank you very much for the useful library.

I think it's better to process the response outside the library. (keep only json decoding in the library)
Is there any reason to not do so?
For example, I want to perform my own process in case of network error in halogen app.
